### PR TITLE
Deprecate azbp015

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ For additional information about each check, see the documentation in passes's d
 
 This tool must be compiled with the **same Go version** required by `terraform-provider-azurerm`. Check the Go version in `terraform-provider-azurerm/go.mod`.
 
+> **Important:** The Go version used to build the linter must match the Go version on your system. Because the linter uses `go/packages` to load and analyze source code, a version mismatch (e.g., binary built with Go 1.25 but system has Go 1.26) will cause errors like:
+> ```
+> file requires newer Go version go1.26 (application built with go1.25)
+> ```
+> If you encounter this, rebuild from source with your current Go version:
+> ```bash
+> go install github.com/qixialu/azurerm-linter@latest
+> ```
+
 **Windows users:** Enable long paths to avoid "Filename too long" errors when using `--pr`:
 ```bash
 git config --global core.longpaths true

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For additional information about each check, see the documentation in passes's d
 | AZBP012 | check for unnecessary else blocks that can be avoided by setting a default |
 | AZBP013 | check for chained nil checks that should be split into separate if statements |
 | AZBP014 | check for empty `OperationOptions` literals when a `Default*` constructor exists |
-| AZBP015 | check that `check.That().Key().HasValue()` is unnecessary when `ImportStep` is used |
+| AZBP015 (DEPRECATED) | check that `check.That().Key().HasValue()` is unnecessary when `ImportStep` is used |
 
 ### Azure New Resource Checks
 

--- a/passes/checks.go
+++ b/passes/checks.go
@@ -20,7 +20,6 @@ var AllChecks = []*analysis.Analyzer{
 	AZBP012Analyzer,
 	AZBP013Analyzer,
 	AZBP014Analyzer,
-	AZBP015Analyzer,
 
 	AZSD001Analyzer,
 	AZSD002Analyzer,


### PR DESCRIPTION
Deprecate azbp015;

Even though it's quite useful for the most of time, it shouldn't be applied to computed fields. However, static analysis is not able to find all fields precisely. To avoid FP, this should be deprecated. (Rationale: https://github.com/hashicorp/terraform-provider-azurerm/pull/31693#discussion_r2916313758)