### PR TITLE
bugfix: PR mode: main worktree history truncated

### DIFF
--- a/loader/worktree_loader.go
+++ b/loader/worktree_loader.go
@@ -77,6 +77,10 @@ func (l *WorktreeLoader) detectRemoteForPR() (string, error) {
 	return "", fmt.Errorf("no suitable remote found (origin or upstream)")
 }
 
+func (l *WorktreeLoader) fetchPRRefArgs() []string {
+	return []string{"fetch", l.remoteName, fmt.Sprintf("refs/pull/%d/head", l.prNumber)}
+}
+
 // Setup fetches the PR and creates a temporary worktree
 func (l *WorktreeLoader) Setup() (string, error) {
 	// 0. Verify we're in a git repository
@@ -101,10 +105,9 @@ func (l *WorktreeLoader) Setup() (string, error) {
 	}
 
 	// 3. Fetch the PR ref
-	prRef := fmt.Sprintf("refs/pull/%d/head", l.prNumber)
 	log.Printf("Fetching PR #%d from remote '%s' (%s/%s)...", l.prNumber, l.remoteName, l.owner, l.repo)
 
-	cmd := exec.Command("git", "fetch", "--depth=1", l.remoteName, prRef)
+	cmd := exec.Command("git", l.fetchPRRefArgs()...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch PR ref: %w\n%s", err, string(output))

--- a/loader/worktree_loader_test.go
+++ b/loader/worktree_loader_test.go
@@ -1,0 +1,21 @@
+package loader
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFetchPRRefArgsAvoidsShallowFetch(t *testing.T) {
+	loader := &WorktreeLoader{
+		prNumber:   123,
+		remoteName: "origin",
+	}
+
+	args := loader.fetchPRRefArgs()
+
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "--depth=") {
+			t.Fatalf("Do not do shallow fetch, it will also truncate the main worktree history. Expected args to not contain any '--depth=<n>' flag, got %v", args)
+		}
+	}
+}


### PR DESCRIPTION
## To reproduce

1. Checkout a PR branch using `gh pr checkout 32174`
2. Run linter in PR mode: `azurerm-linter -pr 32174`
3. Run `git log` in main worktree

- Expected: git history stays intact
- Actual: git history become truncated