### PR TITLE
AZNR002 -  Skip property checking when ResourceData is passed as function argument

### DIFF
--- a/passes/AZNR002.go
+++ b/passes/AZNR002.go
@@ -147,6 +147,11 @@ func findHandledPropertiesInUpdate(pass *analysis.Pass, resource *helper.TypedRe
 	// Pattern 3: ResourceData method calls (HasChange/HasChanges/Get)
 	traceResourceDataCalls(updateFuncBody, resource, handledProps)
 
+	// Pattern 4: If ResourceData is passed as argument to another function (e.g., pluginsdk.GetWriteOnly),
+	if hasResourceDataPassedAsArg(updateFuncBody, resource) {
+		return nil
+	}
+
 	return handledProps
 }
 
@@ -265,6 +270,37 @@ func traceResourceDataCalls(body *ast.BlockStmt, resource *helper.TypedResourceI
 		}
 		return true
 	})
+}
+
+// hasResourceDataPassedAsArg detects if ResourceData is passed as an argument to any function call.
+// This indicates the update logic may be delegated to an external function (e.g., pluginsdk.GetWriteOnly),
+// and we should skip property checking for this resource to avoid false positives.
+func hasResourceDataPassedAsArg(body *ast.BlockStmt, resource *helper.TypedResourceInfo) bool {
+	if body == nil || resource.TypesInfo == nil {
+		return false
+	}
+
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		for _, arg := range call.Args {
+			typ := resource.TypesInfo.TypeOf(arg)
+			if typ != nil && helper.IsTypeResourceData(typ) {
+				found = true
+				return false
+			}
+		}
+
+		return true
+	})
+	return found
 }
 
 // reportMissingProperties reports properties that are updatable but not handled

--- a/passes/testdata/src/aznr002/write_only_resource.go
+++ b/passes/testdata/src/aznr002/write_only_resource.go
@@ -1,0 +1,86 @@
+package aznr002
+
+import (
+	"context"
+	"fmt"
+
+	"testdata/src/mockpkg/pluginsdk"
+	"testdata/src/mockpkg/sdk"
+)
+
+// Test Case: Write-only attribute handled via pluginsdk.GetWriteOnly
+type WriteOnlyResourceModel struct {
+	Name             string `tfschema:"name"`
+	ConnectionString string `tfschema:"connection_string"`
+	ConnectionWO     string `tfschema:"connection_string_wo"`
+}
+
+type WriteOnlyResource struct{}
+
+var _ sdk.ResourceWithUpdate = WriteOnlyResource{}
+
+func (r WriteOnlyResource) ResourceType() string {
+	return "azurerm_write_only_resource"
+}
+
+func (r WriteOnlyResource) ModelObject() interface{} {
+	return &WriteOnlyResourceModel{}
+}
+
+func (r WriteOnlyResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"connection_string": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+		"connection_string_wo": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+	}
+}
+
+func (r WriteOnlyResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r WriteOnlyResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{}
+}
+
+func (r WriteOnlyResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{}
+}
+
+func (r WriteOnlyResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{}
+}
+
+func (r WriteOnlyResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var config WriteOnlyResourceModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			if metadata.ResourceData.HasChange("connection_string") {
+				// Update connection_string
+			}
+
+			// Write-only attribute accessed via pluginsdk.GetWriteOnly - should be detected
+			woVal, err := pluginsdk.GetWriteOnly(metadata.ResourceData, "connection_string_wo", nil)
+			if err != nil {
+				return err
+			}
+			_ = woVal
+
+			return nil
+		},
+	}
+}

--- a/passes/testdata/src/mockpkg/pluginsdk/pluginsdk.go
+++ b/passes/testdata/src/mockpkg/pluginsdk/pluginsdk.go
@@ -19,3 +19,8 @@ type (
 	Schema       = schema.Schema
 	ResourceData = schema.ResourceData
 )
+
+// GetWriteOnly retrieves a write-only attribute value from the ResourceData.
+func GetWriteOnly(d *ResourceData, key string, valType interface{}) (interface{}, error) {
+	return d.Get(key), nil
+}


### PR DESCRIPTION
This handles cases like [pluginsdk.GetWriteOnly(metadata.ResourceData, "connection_string_wo", ...)](vscode-file://vscode-app/c:/Users/qixialu/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) where the linter can't trace into external functions that receive ResourceData, avoiding false positives for write-only attributes.