### PR TITLE
Skip AZSD002 in standalone schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.5 (2026-06-09)
+
+- Improve `AZSD002` by skipping standalone sub-schemas (returned from helper functions or assigned to variables) and any schema nested within them, where the `AtLeastOneOf` / `ExactlyOneOf` fix is not expressible because the schema path depends on where the sub-schema is mounted
+
 ## v0.2.4 (2026-05-27)
 
 - New rule `AZSD005`: check that `None` enum values are not listed in `StringInSlice` validation

--- a/passes/AZSD002.go
+++ b/passes/AZSD002.go
@@ -87,11 +87,26 @@ func runAZSD002(pass *analysis.Pass) (interface{}, error) {
 		schemaInfoByLit[cached.Info.AstCompositeLit] = cached
 	}
 
+	var standaloneLits []*ast.CompositeLit
+	for _, cached := range schemaInfoList {
+		if cached.PropertyName == "" {
+			standaloneLits = append(standaloneLits, cached.Info.AstCompositeLit)
+		}
+	}
+
 	for _, cached := range schemaInfoList {
 		schemaInfo := cached.Info
 		schemaLit := schemaInfo.AstCompositeLit
 
 		if ignorer.ShouldIgnore(azsd002Name, schemaLit) {
+			continue
+		}
+
+		// Skip standalone schemas and anything nested inside one. The schema path
+		// required by AtLeastOneOf / ExactlyOneOf depends on where the standalone
+		// schema is mounted, so the suggested fix is not expressible here (and the
+		// helper may be reused inside repeatable parent blocks).
+		if cached.PropertyName == "" || isInsideAny(schemaLit, standaloneLits) {
 			continue
 		}
 
@@ -198,4 +213,16 @@ func runAZSD002(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	return nil, nil
+}
+
+// isInsideAny returns true if node is positioned strictly within any of the
+// given composite literals (i.e. it is a descendant, not the literal itself).
+func isInsideAny(node ast.Node, lits []*ast.CompositeLit) bool {
+	p := node.Pos()
+	for _, lit := range lits {
+		if p > lit.Pos() && p < lit.End() {
+			return true
+		}
+	}
+	return false
 }

--- a/passes/testdata/src/azsd002/a.go
+++ b/passes/testdata/src/azsd002/a.go
@@ -152,23 +152,3 @@ func invalidCases() map[string]*schema.Schema {
 		},
 	}
 }
-
-func invalidStandaloneCases() *schema.Schema {
-	return &schema.Schema{ // want `AZSD002`
-		Type:     schema.TypeList,
-		Optional: true,
-		MaxItems: 1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"linux": {
-					Type:     schema.TypeList,
-					Optional: true,
-				},
-				"windows": {
-					Type:     schema.TypeList,
-					Optional: true,
-				},
-			},
-		},
-	}
-}


### PR DESCRIPTION
AZSD002 flags TypeList blocks (MaxItems: 1) with all-optional nested fields that lack AtLeastOneOf / ExactlyOneOf, and suggests adding a path-based fix (e.g. setting.0.linux).

That fix doesn't work for schemas defined in a standalone sub-schema (a helper returning *pluginsdk.Schema, or a schema assigned to a variable):

The path depends on where the sub-schema is mounted, which isn't known at the definition site.
These helpers are often mounted inside repeatable parent blocks (e.g. a rules list). Plugin SDK paths are index-pinned (rules.0.actions...) and only validate one element, so enforcement is done in provider validation code instead.
Surfaced on hashicorp/terraform-provider-azurerm#32482 (Front Door batch rule set).