### PR TITLE
Exception to reorder fields as a follow up PR

### DIFF
--- a/passes/AZBP002.go
+++ b/passes/AZBP002.go
@@ -32,7 +32,9 @@ Valid usage:
       Optional: true,
       // NOTE: O+C - field can be set by user or computed from API when not provided
       Computed: true,
-  }`
+  }
+
+Exceptions: change field ordering for an existing resource in a follow-up PR to reduce scope and improve diff readability`
 
 const azbp002Name = "AZBP002"
 

--- a/passes/AZNR001.go
+++ b/passes/AZNR001.go
@@ -29,7 +29,10 @@ Schema fields should be ordered as follows:
 4. Computed fields, sorted alphabetically (with 'location' first if computed)
 5. 'tags' field must be at the end
 
+Exceptions: change field ordering for an existing resource in a follow-up PR to reduce scope and improve diff readability
+
 Special cases:
+
 - Schemas with 'name' field which is optional are skipped
 - If optional fields appear before required fields, their original order is preserved
   (This happens when some resources have optional fields as part of the resource ID components)


### PR DESCRIPTION
## Summary

As discussed in HashiCorp office hours: reordering fields of an existing resource makes PR diff harder to review. They should be done as a follow up PR instead.

Affected rule: AZBP002 and AZNR001.

