### PR TITLE
Fix: worktree support and synced go version with AzureRM

### DIFF
--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -85,10 +85,7 @@ func (r *Runner) Run(ctx context.Context) ExitCode {
 	}
 
 	log.Printf("Loading packages...")
-	cfg := &packages.Config{
-		Mode:  packages.LoadAllSyntax,
-		Tests: true,
-	}
+	cfg := helper.NewPackageLoadConfig("", true)
 	pkgs, err := packages.Load(cfg, patterns...)
 	if err != nil {
 		if isJSON {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qixialu/azurerm-linter
 
-go 1.25.3
+go 1.26.3
 
 require (
 	github.com/bflad/tfproviderlint v0.31.0

--- a/helper/package_config.go
+++ b/helper/package_config.go
@@ -1,0 +1,12 @@
+package helper
+
+import "golang.org/x/tools/go/packages"
+
+func NewPackageLoadConfig(dir string, tests bool) *packages.Config {
+	return &packages.Config{
+		Mode:       packages.LoadAllSyntax,
+		Tests:      tests,
+		Dir:        dir,
+		BuildFlags: []string{"-buildvcs=false"},
+	}
+}

--- a/helper/package_config_test.go
+++ b/helper/package_config_test.go
@@ -1,0 +1,25 @@
+package helper
+
+import (
+	"testing"
+)
+
+func TestNewPackageLoadConfigDisablesVCSStamps(t *testing.T) {
+	cfg := NewPackageLoadConfig("/tmp/example", true)
+
+	if cfg == nil {
+		t.Fatal("NewPackageLoadConfig() returned nil")
+	}
+
+	if !cfg.Tests {
+		t.Fatal("NewPackageLoadConfig() should enable test package loading")
+	}
+
+	if cfg.Dir != "/tmp/example" {
+		t.Fatalf("NewPackageLoadConfig() Dir = %q, want %q", cfg.Dir, "/tmp/example")
+	}
+
+	if len(cfg.BuildFlags) != 1 || cfg.BuildFlags[0] != "-buildvcs=false" {
+		t.Fatalf("NewPackageLoadConfig() BuildFlags = %v, want [-buildvcs=false]", cfg.BuildFlags)
+	}
+}

--- a/passes/schema/common_schema_info.go
+++ b/passes/schema/common_schema_info.go
@@ -133,10 +133,7 @@ func loadSchemaInfo(pass *analysis.Pass) *CommonSchemaInfo {
 		return info
 	}
 
-	cfg := &packages.Config{
-		Mode: packages.LoadAllSyntax,
-		Dir:  vendorPath,
-	}
+	cfg := helper.NewPackageLoadConfig(vendorPath, false)
 
 	// Load commonschema package from vendor
 	pkgs, err := packages.Load(cfg, "./...")


### PR DESCRIPTION
This PR fixes a bug where the linter is run from a git worktree. To reproduce:

1. Setup a worktree: `git worktree add -b my-feature /path/to/azurem-worktrees/my-feature upstream/main
2. Run the linter

Previously I got the following error:

```bash
2026/07/08 11:22:42 Error: failed to load package: -: error obtaining VCS status: exit status 128
        Use -buildvcs=false to disable VCS stamping.
```

I also bumped to go version to be in sync with AzureRM to fix a diffferent package loading error due to version mismatch.